### PR TITLE
Hotfix: Include all relevant package files in the template

### DIFF
--- a/.altostra/template.json
+++ b/.altostra/template.json
@@ -2,7 +2,12 @@
 	"name": "Static Website",
 	"description": "A static website with CDN distribution",
 	"includes": [
-		"/public/**"
+		"/public/**",
+		"/package*.json",
+		"/.altoignore",
+		"/.gitignore",
+		"/README.md",
+		"/LICENSE"
 	],
 	"excludes": [],
 	"blueprints": [


### PR DESCRIPTION
Change the `template.json` file to include all of the relevant files that must be created when initializing a project from this template, such as README and LICENSE.